### PR TITLE
🩹 fix hyperlink bluehats helm

### DIFF
--- a/content/fr/bluehats/gazettes/bluehats_24.md
+++ b/content/fr/bluehats/gazettes/bluehats_24.md
@@ -1,0 +1,91 @@
+---
+title: Gazette BlueHats 🧢 n°24
+date: 2023-09-16
+---
+
+## 🚀 Nouvelles de la mission
+### Faites connaître vos progrès dans l'utilisation ou le développement de logiciels libres
+
+Vous êtes une administration et portez une initiative autour du libre ?  C'est la saison des prix !  Rendez-vous sur [notre entrée de blog](https://code.gouv.fr/fr/blog/faites-reconnaitre-vos-efforts-dutilisation-de-logiciels-libres/) pour découvrir le label Territoire Numérique Libre, le prix OSOR de l'Union européenne et le prix du « service public engagé » (lesacteursdulibre.com).
+
+### Des outils libres pour renforcer la transparence algorithmique
+
+La mission logiciels libres publie une nouvelle page dédiée aux [outils libres pour renforcer la transparence algorithmique](https://code.gouv.fr/fr/explicabilite/) où nous présentons le vénérable [OpenFisca](https://openfisca.org/en/), l'astucieux [Publi.Codes](https://publi.codes/) et l'intriguant [Catala](https://catala-lang.org/).
+
+### Retour sur la journée Helm Charts d'avril
+
+Nous publions un [résumé de la journée consacrée à la mutualisation des
+charts Helm][helm charts day].  Pour poursuivre les échanges et la collaboration, rendez-vous sur le dépôt [awesome-bluehats-helm](https://github.com/codegouvfr/awesome-bluehats-helm) !
+
+[helm charts day]: https://code.gouv.fr/fr/bluehats/helm-charts-2023/
+
+### Permanences de la mission logiciels libres
+
+Les membres de la mission logiciels libres répondent à vos questions les lundi de 17h à 18h sur IRC et, pour les agents publics, les jeudi de 11h à 12h sur le salon Tchap BlueHats.
+
+Voir la page où nous présentons [les moyens d'entrer en contact avec la communauté BlueHats](https://code.gouv.fr/fr/contact/espaces-communication-bluehats/).
+
+## 🗳️ Consultation des agents publics : une boîte à idée très libre !
+
+Consultés sur les [outils numériques](https://www.fonction-publique-plus.gouv.fr/participation/boite-a-idees/liste/thematiques/outils-numeriques), certains agents publics font mention des logiciels libres.  N'hésitez pas à ajouter votre voix à la leur !
+
+## ✍🏾 Le libre et les communs numériques dans les compétences et métiers d'avenir
+
+L’appel à manifestation d’intérêt « [Compétences et métiers d’avenir](https://www.gouvernement.fr/competences-et-metiers-d-avenir) » a produit des [informations et fiches thématiques](https://www.gouvernement.fr/cma-informations-et-fiches-thematiques).  Pour atteindre les priorités France 2030, la « maîtrise de technologies numériques souveraines et sûres » est identifiée comme levier.
+
+Dans la partie « Enseignement et numérique » du [document](https://www.gouvernement.fr/sites/default/files/contenu/piece-jointe/2023/07/levier_maitriser_les_technologies_numeriques_ok_ov_ajout_ensnum_verdissement_ok.pdf) détaillant les enjeux liés à ce levier, nous retrouvons une proposition d'action sur « La formation au libre et aux communs numériques » :
+
+:::quote
+Dans l'éducation et l’enseignement supérieur, le libre et les communs numériques sont une réponse au besoin croissant de la communauté scolaire et universitaire de mutualiser et collaborer entre pairs en créant et partageant des ressources numériques pérennes et accessibles à toutes et tous dans un cadre de confiance inclusif et soucieux de la protection des données personnelles. L'idée directrice est que les ressources pédagogiques préparées par un enseignant ou un groupe d’enseignants puissent resservir à d’autres sans obstacle. Il s'agit tout autant d'utiliser des ressources que de contribuer collectivement à leur production, en consolidant ses compétences numériques. On apporte ses compétences à la communauté et on en développe de nouvelles par la pratique au contact de ses collègues.
+:::
+
+<br/>
+
+## 📖 Publication d'un nouveau livre sur Matomo
+
+Un livre consacré à [Matomo](https://code.gouv.fr/sill/detail?name=Matomo), logiciel libre d'analyse d'audience, est paru aux Editions ENI en avril dernier. Il s'agit d'un ouvrage consacré à l'installation de Matomo sur le serveur de votre choix. En parallèle de cela, la version 5 de Matomo a vu le jour au mois de juin. Parmi les changements majeurs le passage de AngularJS à Vue.js.
+
+Si vous connaissez le logiciel Matomo et que vous souhaitez faire un retour d'expérience ou animer une conférence sur ce logiciel, l'édition 3 de MatomoCamp aura lieu les 9 et 10 novembre prochain.
+
+`>>` [Consulter le livre](https://www.editions-eni.fr/livre/matomo-l-outil-de-web-analytics-libre-et-ethique-9782409039607)
+
+`>>` [Site officiel de MatomoCamp](https://matomocamp.org)
+
+<br/>
+
+## 📅 Événements
+
+- [Lutece Translation Hackathon](https://lutece.paris.fr/en/jsp/site/Portal.jsp?page=blog&id=66&portlet_id=17), le 16 octobre, un événement #BlueHats organisé par la ville de Paris
+- [Campus du libre](https://www.campus-du-libre.org), le 21 octobre, un événement autour du libre organisé par des personnes issues du milieu universitaire (étudiants et personnels) pour les étudiants lyonnais.
+
+<br/>
+
+## 📰 Revue de presse
+
+### En français
+
+- [IA : cette menace qui plane au-dessus de ChatGPT](https://www.lexpress.fr/economie/high-tech/ia-cette-menace-qui-plane-au-dessus-de-chatgpt-UYK3OWCEC5DFTHBM63TZWK3VCE/), lexpress.fr, septembre 2023
+- [L’État veut lever le risque juridique lié au partage de ses outils numériques avec les collectivités](https://acteurspublics.fr/articles/letat-veut-lever-le-risque-juridique-lie-au-partage-de-ses-outils-numeriques-avec-les-collectivites), acteurspublics.fr, septembre 2023
+- [Communs numériques : explorer l’hypothèse des organisations frontières ](https://cnnumerique.fr/paroles-de/communs-numeriques-explorer-lhypothese-des-organisations-frontieres), cnnumerique.fr, septembre 2023
+- [Les 14 logiciels libres entrés au SILL cet été](https://www.silicon.fr/logiciels-libres-sill-ete-2023-470983.html), silicon.fr, septembre 2023
+- [Une liste des codes source des projets gouvernementaux et du secteur public français](https://code-garage.fr/blog/codes-source-des-projets-gouvernementaux-et-du-secteur-public-francais/), code-garage.fr, septembre 2023
+- [Le gouvernement lance un site web gratuit pour sécuriser des documents sensibles](https://www.lesnumeriques.com/appli-logiciel/le-gouvernement-lance-un-site-web-gratuit-pour-securiser-des-documents-sensibles-n212259.html), lesnumeriques.com, août 2023
+- [La Software Freedom Conservancy appelle les développeurs open source à abandonner Zoom et à adopter BigBlueButton](https://open-source.developpez.com/actu/347422/La-Software-Freedom-Conservancy-appelle-les-developpeurs-open-source-a-abandonner-Zoom-et-a-adopter-BigBlueButton-suite-a-un-changement-vivement-critique-dans-ses-conditions-d-utilisation/), developpez.com, août 2023
+- [La messagerie instantanée de l’État au défi du “passage à l’échelle”](https://acteurspublics.fr/articles/la-messagerie-instantanee-de-letat-au-defi-du-passage-a-lechelle), acteurspublics.fr, août 2023
+- [Cyber Resilience Act : le futur du logiciel libre en suspend en attendant le trilogue](https://www.april.org/cyber-resilience-act-le-futur-du-logiciel-libre-en-suspend-en-attendant-le-trilogue), april.org, août 2023
+- [Cybersécurité : les logiciels libres menacés par un excès de règles ](https://www.bsmart.fr/video/21153-smart-tech-partie-29-aout-2023), bsmart.fr, août 2023, transcription à lire sur [librealire.org](https://www.librealire.org/cybersecurite-les-logiciels-libres-menaces-par-un-exces-de-regles-smart-tech)
+- [MADIS : le logiciel Opensource pour gérer votre conformité au RGPD](https://linuxfr.org/news/madis-le-logiciel-opensource-pour-gerer-votre-conformite-au-rgpd), linuxfr.org, août 2023
+- [Que veut dire « libre » (ou « open source ») pour un grand modèle de langage ?](https://framablog.org/2023/07/31/que-veut-dire-libre-ou-open-source-pour-un-grand-modele-de-langage/), framasoft.org, juillet 2023
+- [Le logiciel libre, l’open source et l’État. Échange avec Stefano Zacchiroli ](https://cnnumerique.fr/paroles-de/le-logiciel-libre-lopen-source-et-letat-echange-avec-stefano-zacchiroli), juin 2023
+
+<br/>
+
+### En anglais
+
+- [New RFI shows the U.S. gov effort to invest in open source is picking up steam](https://blog.tidelift.com/new-rfi-shows-the-us-gov-effort-to-invest-in-open-source-is-picking-up-steam), tidelift.com, août 2023
+- [France bets big on open-source AI](https://www.politico.eu/article/open-source-artificial-intelligence-france-bets-big/), politico.eu, août 2023
+- [It Takes a Village: Open Source Software Sustainability](https://academiccommons.columbia.edu/doi/10.7916/D89G70BS), academiccommons.columbia.edu, 2018
+- [The future of Europe’s Sovereign Cloud – An exclusive interview with Alfons Buxó (Deloitte)](https://sovereignedge.eu/blog/the-future-of-europes-sovereign-cloud-an-exclusive-interview-with-alfons-buxo-deloitte/), sovereignedge.eu, juillet 2023
+- [Enabling OSS Innovation in Universities ](https://ospoplusplus.org/resource/enabling-oss-innovation-in-universities/), ospoplusplus.org, 2023
+- [Collaborating for Open Source Innovation](https://ospoplusplus.org/resource/collaboration-for-open-source-innovation/), ospoplusplus.org, 2023
+- [Opening up ChatGPT: tracking "open source" LLM + RLHF architectures](https://opening-up-chatgpt.github.io/), opening-up-chatgpt.github.io, 2023


### PR DESCRIPTION
Replace the hyperlink

`https://code.gouv.fr/fr/bluehats/retour-sur-la-journee-helm-charts-avril-2023/`

with the correct one

`https://code.gouv.fr/fr/bluehats/helm-charts-2023/`.