### PR TITLE
Composant alerte

### DIFF
--- a/_includes/components/alert.njk
+++ b/_includes/components/alert.njk
@@ -1,0 +1,7 @@
+{% if not alert %}{% set alert = params %}{% endif %}
+<div class="fr-alert {% if alert.type %}fr-alert--{{ alert.type }}{% else %}fr-alert--info{% endif %} {% if not alert.title %}fr-alert--sm{% endif %}">
+    {% if alert.title %}
+        <h3 class="fr-alert__title">{{ alert.title | safe }}</h3>
+    {% endif %}
+    {% if alert.description %}{{ alert.description | safe }}{% endif %}
+</div>

--- a/content/fr/blog/posts/alert.md
+++ b/content/fr/blog/posts/alert.md
@@ -1,0 +1,59 @@
+---
+title: Alerte
+description: Comment intégrer une alerte dans une page du site ?
+date: git Last Modified
+tags:
+  - DSFR
+  - composant
+---
+
+Ce composant peut être inclus dans un fichier Nunjucks `.njk` ou Markdown `.md`.
+
+## Exemple d'utilisation
+
+```njk
+{% raw %}
+{% from "components/component.njk" import component with context %}
+{{ component("alert", {
+    type: "info",
+    title: "Test d'alerte",
+    description: "<p>Le contenu de l'alerte</p>"
+}) }}
+{% endraw %}
+```
+
+**Notes :**
+
+Le composant alerte n'inclut pas de bouton de fermeture.
+
+Le bloc ne porte pas l'attribut `role="alert"` car il n’apparait pas dynamiquement en cours de navigation.
+
+Les types possibles sont `info`, `warning`, `error`, `success`. Si le type est omis, le type `info` sera appliqué.
+
+## Rendu
+
+{% from "components/component.njk" import component with context %}
+{{ component("alert", {
+    type: "info",
+    title: "Titre de l'information",
+    description: "<p>Le contenu de l'alerte</p>"
+}) }}
+
+{% from "components/component.njk" import component with context %}
+{{ component("alert", {
+    type: "warning",
+    title: "Titre de l'avertissement",
+    description: "<p>Le contenu de l'alerte</p>"
+}) }}
+
+{% from "components/component.njk" import component with context %}
+{{ component("alert", {
+    type: "success",
+    description: "<p>Contenu de l'alerte seul</p>"
+}) }}
+
+{% from "components/component.njk" import component with context %}
+{{ component("alert", {
+    type: "error",
+    title: "Titre d'une erreur simple"
+}) }}


### PR DESCRIPTION
Je propose l'ajout du composant **alerte** du DSFR (https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/alerte/).

Comme il est utilisé dans le cadre d'un site statique et n'apparait pas dynamiquement, le bouton de fermeture n'est pas disponible et le bloc ne porte pas l'attribut `role="alert"` dans mon implémentation.

![image](https://github.com/codegouvfr/eleventy-dsfr/assets/28899274/619d84eb-c404-462d-9c84-678ec04c5d37)

----

Un ajout en markdown avec un traitement à la façon des "[admonitions](https://squidfunk.github.io/mkdocs-material/reference/admonitions/)" serait bienvenu dans un second temps pour simplifier le travail des rédacteurs. Avec une syntaxe de la forme : 

```md
!!! info Titre de l'information

    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla et euismod
    nulla. Curabitur feugiat, tortor non consequat finibus, justo purus auctor
    massa, nec semper lorem quam in massa.
```