### PR TITLE
Composant accordéon en markdown

### DIFF
--- a/content/fr/blog/posts/accordeon.md
+++ b/content/fr/blog/posts/accordeon.md
@@ -24,6 +24,8 @@ Contenu **markdown** _riche_
 ????
 ```
 
+NB: Le conteneur _accordionsgroup_ est facultatif quand il n'y a qu'un seul accordéon.
+
 ### Exemple d'utilisation dans un fichier Nunjucks `.njk`
 
 ```njk

--- a/content/fr/blog/posts/accordeon.md
+++ b/content/fr/blog/posts/accordeon.md
@@ -24,7 +24,7 @@ Contenu **markdown** _riche_
 ????
 ```
 
-NB: Le conteneur _accordionsgroup_ est facultatif quand il n'y a qu'un seul accordéon.
+**Note :** Le conteneur `accordionsgroup` est facultatif quand il n'y a qu'un seul accordéon.
 
 ### Exemple d'utilisation dans un fichier Nunjucks `.njk`
 

--- a/content/fr/blog/posts/accordeon.md
+++ b/content/fr/blog/posts/accordeon.md
@@ -22,7 +22,23 @@ Chaque composant peut être inclus dans un fichier Nunjucks `.njk` ou Markdown `
 {% endraw %}
 ```
 
+ou
+
+```md
+:::accordionsgroup
+
+???accordion Intitulé accordéon
+
+Contenu **markdown** _riche_
+
+???
+
+:::
+```
+
 ## Rendu
+
+Un accordéon créé en njk :
 
 {% from "components/component.njk" import component with context %}
 {{ component("accordionsgroup", {
@@ -31,6 +47,44 @@ Chaque composant peut être inclus dans un fichier Nunjucks `.njk` ou Markdown `
         content: "<p>Contenu HTML</p>"
     }]
 }) }}
+
+<br>
+
+Groupe d'accordéons créé en markdown :
+
+:::accordionsgroup
+
+???accordion Premier accordéon
+
+Contenu MD
+
+* one
+* two
+
+???
+
+???accordion Deuxième accordéon
+
+Contenu **markdown** _riche_
+
+```sh
+git commit
+git push
+```
+
+???
+
+:::
+
+<br>
+
+Un autre accordéon seul :
+
+???accordion Accordéon seul, hors groupe
+
+Lorem [...] elit ut.
+
+???
 
 <br>
 

--- a/content/fr/blog/posts/accordeon.md
+++ b/content/fr/blog/posts/accordeon.md
@@ -8,7 +8,23 @@ tags:
 ---
 Chaque composant peut être inclus dans un fichier Nunjucks `.njk` ou Markdown `.md`.
 
-## Exemple d'utilisation
+## Utilisation
+
+### Exemple d'utilisation dans un fichier Markdown `.md`
+
+```md
+????accordionsgroup
+
+??? Intitulé accordéon
+
+Contenu **markdown** _riche_
+
+???
+
+????
+```
+
+### Exemple d'utilisation dans un fichier Nunjucks `.njk`
 
 ```njk
 {% raw %}
@@ -22,23 +38,9 @@ Chaque composant peut être inclus dans un fichier Nunjucks `.njk` ou Markdown `
 {% endraw %}
 ```
 
-ou
-
-```md
-:::accordionsgroup
-
-???accordion Intitulé accordéon
-
-Contenu **markdown** _riche_
-
-???
-
-:::
-```
-
 ## Rendu
 
-Un accordéon créé en njk :
+Un accordéon créé en Nunjucks :
 
 {% from "components/component.njk" import component with context %}
 {{ component("accordionsgroup", {
@@ -50,11 +52,11 @@ Un accordéon créé en njk :
 
 <br>
 
-Groupe d'accordéons créé en markdown :
+Groupe d'accordéons créé en Markdown :
 
-:::accordionsgroup
+????accordionsgroup
 
-???accordion Premier accordéon
+??? Premier accordéon
 
 Contenu MD
 
@@ -63,7 +65,7 @@ Contenu MD
 
 ???
 
-???accordion Deuxième accordéon
+??? Deuxième accordéon
 
 Contenu **markdown** _riche_
 
@@ -74,13 +76,13 @@ git push
 
 ???
 
-:::
+????
 
 <br>
 
 Un autre accordéon seul :
 
-???accordion Accordéon seul, hors groupe
+??? Accordéon seul, hors groupe
 
 Lorem [...] elit ut.
 

--- a/content/fr/blog/posts/md-cheatsheet.md
+++ b/content/fr/blog/posts/md-cheatsheet.md
@@ -12,6 +12,21 @@ La syntaxe utilisée dans les fichiers Markdown `.md` du site suit la spécifica
 
 **De nouveaux éléments** ont été ajoutés à cette syntaxe et sont disponibles dans eleventy-dsfr.
 
+## L'accordéon
+
+```md
+????accordionsgroup
+
+??? Intitulé accordéon
+
+Contenu **markdown** _riche_
+
+???
+
+????
+```
+[Voir aussi](/fr/blog/accordeon/#exemple-d-utilisation-dans-un-fichier-markdown-md){.fr-link .fr-fi-arrow-right-line .fr-link--icon-right}
+
 ## L'alerte
 
 ```md

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -170,6 +170,7 @@ module.exports = function (eleventyConfig) {
     });
 
     eleventyConfig.amendLibrary("md", mdLib => {
+
         mdLib.use(markdownItContainer, 'accordion', customMarkdownContainers.accordion(mdLib));
     });
 

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -170,7 +170,6 @@ module.exports = function (eleventyConfig) {
     });
 
     eleventyConfig.amendLibrary("md", mdLib => {
-
         mdLib.use(markdownItContainer, 'accordion', customMarkdownContainers.accordion(mdLib));
     });
 

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -169,6 +169,10 @@ module.exports = function (eleventyConfig) {
         mdLib.use(markdownItContainer, 'alert', customMarkdownContainers.alert(mdLib));
     });
 
+    eleventyConfig.amendLibrary("md", mdLib => {
+        mdLib.use(markdownItContainer, 'accordion', customMarkdownContainers.accordion(mdLib));
+    });
+
     // Automatically strip all leading or trailing whitespace
     // to prevent Markdown lib from rendering with wrapping into paragraphs
     // instead of using Nunjucks special syntax. Learn more:

--- a/markdown-custom-containers.js
+++ b/markdown-custom-containers.js
@@ -88,5 +88,44 @@ module.exports = {
                 }
             }
         }
+    },
+    accordion: md => {
+        const re = /^(accordionsgroup|.*)?$/;
+        return {
+            validate: (params) => {
+                return params.trim().match(re);
+            },
+
+            render: (tokens, idx) => {
+                const params = tokens[idx].info.trim().match(re);
+
+                if (tokens[idx].nesting === 1) {
+                    // opening tag
+                    if (params?.[1] === "accordionsgroup") {
+                        return `<div class="fr-accordions-group">`;
+                    } else {
+                        return `
+<section class="fr-accordion">
+    <h3 class="fr-accordion__title">
+        <button class="fr-accordion__btn" aria-expanded="false" aria-controls="accordion-${idx}">
+            ${md.utils.escapeHtml(params?.[1]) || ""}
+        </button>
+    </h3>
+    <div class="fr-collapse" id="accordion-${idx}">
+`;
+                    }
+                } else {
+                    // closing tag
+                    if (params?.[1] === "accordionsgroup") {
+                        return `</div>`;
+                    } else {
+                        return '</div></section>\n';
+                    }
+                }
+            },
+
+            marker: "?"
+        }
     }
+
 }


### PR DESCRIPTION
Proposition de containers imbriqués pour la gestion des accordéons : 

* **accordionsgroup** (sans paramètre)
* **accordion** (avec le titre en paramètre et le marqueur `???` pour rendre le markdown plus lisible)

Pour un seul accordéon, le premier container n'est pas nécessaire.

----

Dans un groupe d'accordéons, il est dommage de ne pas pouvoir indenter les containers pour rendre le markdown plus lisible. Il me semble qu'il s'agit là d'une limitation de `markdown-it-container`. Il ne me semble pas possible non plus d'utiliser les marqueurs seuls.

Dans l'idéal j'aurais aimé une syntaxe comme suit : 

```md
:::accordionsgroup

    ??? Premier accordéon
        
        Contenu MD

    ??? Deuxième accordéon

        Contenu MD du deuxième accordéon

:::
```

plus lisible que : 

```md
:::accordionsgroup

???accordion Premier accordéon

Contenu MD

???

???accordion Deuxième accordéon

Contenu MD du deuxième accordéon

???

:::
````

Issue en référence : closes #17