### PR TITLE
feat: add markdown-it-footnote plugin support

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -4,6 +4,7 @@ const {nanoid} = require ("nanoid");
 const markdownItAnchor = require("markdown-it-anchor");
 const markdownItAttrs = require("markdown-it-attrs");
 const markdownItContainer = require("markdown-it-container");
+const markdownItFootnote = require("markdown-it-footnote");
 
 const pluginRss = require("@11ty/eleventy-plugin-rss");
 const pluginSyntaxHighlight = require("@11ty/eleventy-plugin-syntaxhighlight");
@@ -183,6 +184,10 @@ module.exports = function (eleventyConfig) {
 
     eleventyConfig.amendLibrary("md", mdLib => {
         mdLib.use(markdownItContainer, 'accordion', customMarkdownContainers.accordion(mdLib));
+    });
+
+    eleventyConfig.amendLibrary("md", mdLib => {
+        mdLib.use(markdownItFootnote);
     });
 
     // Automatically strip all leading or trailing whitespace

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "markdown-it-anchor": "^8.6.7",
         "markdown-it-attrs": "^4.2.0",
         "markdown-it-container": "^4.0.0",
+        "markdown-it-footnote": "^4.0.0",
         "pagefind": "^1.2.0"
       },
       "engines": {
@@ -2205,6 +2206,13 @@
       "resolved": "https://registry.npmjs.org/markdown-it-container/-/markdown-it-container-4.0.0.tgz",
       "integrity": "sha512-HaNccxUH0l7BNGYbFbjmGpf5aLHAMTinqRZQAEQbMr2cdD3z91Q6kIo1oUn1CQndkT03jat6ckrdRYuwwqLlQw==",
       "dev": true
+    },
+    "node_modules/markdown-it-footnote": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-footnote/-/markdown-it-footnote-4.0.0.tgz",
+      "integrity": "sha512-WYJ7urf+khJYl3DqofQpYfEYkZKbmXmwxQV8c8mO/hGIhgZ1wOe7R4HLFNwqx7TjILbnC98fuyeSsin19JdFcQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/markdown-it/node_modules/argparse": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "markdown-it-anchor": "^8.6.7",
     "markdown-it-attrs": "^4.2.0",
     "markdown-it-container": "^4.0.0",
+    "markdown-it-footnote": "^4.0.0",
     "pagefind": "^1.2.0"
   }
 }


### PR DESCRIPTION
Closes #20

Adds support for Markdown footnotes using the `markdown-it-footnote` plugin.

The plugin is registered via `eleventyConfig.amendLibrary` following the same pattern as the other markdown-it plugins already present in the configuration.

Usage example:
Some text with a footnote.[^1]

[^1]: The footnote content.